### PR TITLE
Concept map changes:  Added EC, MS5803, applied projects

### DIFF
--- a/ConceptMap.tex
+++ b/ConceptMap.tex
@@ -15,6 +15,8 @@
 \setcounter{rowno}{0}
 \newcounter{chptno}
 \setcounter{chptno}{0}
+\newcounter{deviceno}
+\setcounter{deviceno}{0}
 
 
 \usepackage{tikz}
@@ -68,11 +70,19 @@
       %& &  |[root]| Prosection               \\
       |[blank]|Section     & |[blank]|Background  & |[blank]|Activity/HOW-TO/ Milestone  & |[blank]|Skill &  |[blank]|Science/Engineering topic & |[blank]|Core concept  \\
 %
-       |[part]| \textbf{PART I: INTRODUCTION}   & &      & &        &      \\
-
-      \stepcounter{chptno}\thechptno. \textbf{Communicating w/ your microcontroller}   & & Meet your microcontroller     & &        &      \\
-      % 1. \textbf{Communicating w/ your microcontroller}   & & Meet your microcontroller     & &        &      \\
-          \thechptno.1 Establishing communications    &  &    & &        &      \\
+       |[part]| \textbf{PART I: PRELIMINARIES}   & &      & &        &      \\
+       \stepcounter{chptno}
+%
+       \thechptno. \textbf{Introduction}\\
+%
+       \thechptno.1 \textbf{Setting things up} & \thechptno.1.1 Hardware/software choices for textbook & & & Explain distinction between single board computer and microcontroller, MicroPython vs. Arduino & Open source hardware development \\
+       & \thechptno.1.2 Types of microcontrollers & & Evalute features of microcontrollers relevant for environmental sensing \\
+       & \thechptno.1.3 Tools needed for developing in MicroPython & Install Drivers for USB  & & & & \\
+       & & Install Thonny & & & & \\
+       & & Updating/Flashing Micropython & & Software versioning, Code repositories & \\
+      \thechptno.2 \textbf{Communicating w/ your microcontroller} & & Meet your microcontroller & & & \\
+          % 1. \textbf{Communicating w/ your microcontroller}   & & Meet your microcontroller     & &        &      \\
+          \thechptno.2 Establishing communications    &  &    & &        &      \\
           \thechptno.2 Connecting via USB    & \thechptno.2.1 Installing drivers for USB &    & &        &      \\
               & \thechptno.2.2 USB connections via Chrome & Connect via BeagleTerm & Wired communication with microcontrollers &        &      \\
               & \thechptno.2.3 USB connections via mpfshell &   Install mpfshell & &        &      \\
@@ -114,22 +124,25 @@
        |[part]| \textbf{PART II: FUNDAMENTALS OF ENVIRONMENTAL SENSING}   & &      & &        &      \\
 
       \stepcounter{chptno}\thechptno. \textbf{Environmental sensing w/ voltage, current and resistance}   &  &    & &        &      \\
-          \thechptno.1 Measuring voltage    & \thechptno.1.1 Voltage of an 18650 battery &    & &        &      \\
-              & Ohm's Law for voltage, current and resistance &    & & Voltage, current \& resistance/ Ohm's Law   &   Sensor range, resolution \& saturation (ADC voltage limits \& resolution)   \\
-              & Designing a voltage divider using Ohm's Law & Design a voltage divider circuit   & Ohm's Law calculations  &        & Circuit design, analysis \& testing     \\
+          \thechptno.1 Measuring voltage    & \thechptno.1.1 Voltage of an 18650 battery  & Use a multimeter &        &      \\
+              & \thechptno.1.2 Ohm's Law for voltage, current and resistance &    & & Voltage, current \& resistance/ Ohm's Law   &   Sensor range, resolution \& saturation (ADC voltage limits \& resolution)   \\
+              & \thechptno.1.3 Designing a voltage divider using Ohm's Law & Design a voltage divider circuit   & Ohm's Law calculations  &        & Circuit design, analysis \& testing     \\
               &  & Assemble/test a voltage divider circuit   & Breadboard circuit layout \& debugging &        &   \\
-          \thechptno.2 Environmental sensing w/ voltage: measure voltage w/ a thermistor    & \thechptno.2.1 Thermistor temperature resistance curves & Calibrate a thermistor   & &   Temperature effects on sensors     &      \\
+          \thechptno.2 Environmental sensing w/ voltage: measure temperature and electrical conductivity & \thechptno.2.1 What is EC?  Why does it depend on temperature? & & & & Relationship between EC and salinity/water quality \\
+              & \thechptno.2.1 Thermistor temperature resistance curves & Calibrate a thermistor   & &   Temperature effects on sensors     &      \\
               & \thechptno.2.2 Thermistor circuit design & Design a voltage divider for a thermistor   & GPIO interfaces (ADC) &  Data encoding  &  Calibration \& ground truthing    \\
-              & \thechptno.2.3 Thermistor circuit assembly \& programming & Build \& test a thermistor circuit   & &        &      \\
+              & \thechptno.2.3 Thermistor circuit assembly \& programming & build \& test a thermistor circuit & & & &     \\
+              & \thechptno.2.4 EC circuit assembly \& programming & build \& test an EC circuit  & Signal acquisition (current measurement, 2 wire vs. 4 wire) & AC vs. DC, electrical fields & \\
+              & \thechptno.2.5 EC circuit calibration & Calibrate EC circuit w/ KCl Standard & Regression/optimization in Python & & Accuracy vs. precision, bias  \\
           \thechptno.3 Environmental sensing w/ time: measuring light intensity with frequency    & \thechptno.3.1 Measuring light with frequency & Assemble \& test a frequency-based light sensor circuit   & Breadboard circuit layout \& debugging &        &      \\
               & \thechptno.3.2 Dividing frequency to increase sensor range & Measure divided frequency from a light sensor   & GPIO interfaces & Microcontroller responses to environmental signals       &      Sensor range, resolution \& saturation ($\mu s$ measurement limits)\\
               & \thechptno.3.3 Optimizing a light sensor driver & Optimize a light sensor driver   & Python coding (drivers) &        &      \\
           \thechptno.4 Environmental sensing with time: Calibrate an acoustic distance sensor   &  &      \\
-
       \stepcounter{chptno}\thechptno. \textbf{Digital interfaces for environmental sensors}   & \thechptno.0.1 Communicating with digital sensors &    & &        &      \\
-          \thechptno.1 I2C sensors   & \thechptno.1.1 Background &      \\
-             & \thechptno.1.2 Measuring temperature with a high-resolution sensor   & Measure temperature with an MCP9808 precision temperature sensor &        &    \\
-             & \thechptno.1.\thechptno Using I2C over long cables with differential extenders   & Implement an I2C sensor over an ethernet cable &        &    \\
+            \thechptno.1 I2C sensors   & \thechptno.1.1 Background &      \\
+            & \thechptno.1.2 Measuring temperature with a high-resolution sensor   & Measure temperature with an MCP9808 precision temperature sensor &        &    \\
+            & \thechptno.1.3 Multiple Sensors on a Device: Temperature and Pressure on MS5803 & Water depth/temperature profiles & Printed Circuit Boards/SMT Assembly & Hydrostatics, temperature stratification & Sensor Range and Error Propagation  \\
+            & \thechptno.1.4 Using I2C over long cables with differential extenders   & Implement an I2C sensor over an ethernet cable &        &    \\
           \thechptno.2 1-wire sensors   &  \thechptno.2.1 Background &      \\
              & \thechptno.2.2 Temperature measurements with DS18B20 digital sensors &  Sample temperatures from multiple ``cabled'' sensors   &  &        &    \\
              & \thechptno.2.4 Accuracy \& precision of DS18B20 temperature sensors & Quantify errors with a high-resolution temperature sensor   &   &        &    \\
@@ -142,17 +155,28 @@
              & \thechptno.3.4 Tracking ships using Automatic Identification System (AIS) &  Track vessels using an AIS receiver  &  &        &    \\
           \thechptno.4 SPI sensors   &  \thechptno.4.1 Background (SD card interfaces)&      \\
              & \thechptno.4.2 SPI control of TFT display panels &    &  &        &    \\
-
+%
+%
+      |[part]| \textbf{PART III: PRACTICAL SKILLS IN ENVIRONMENTAL SENSING}   & &      & &        &      \\
+      \stepcounter{chptno}\thechptno. \textbf{Planning and field skills}   & \thechptno.1 Documenting field conditions, Deployment checklists   & &        &      \\
+      \stepcounter{chptno}\thechptno.  \textbf{Power supply \& regulation for environmental instruments} & \thechptno.1 Power usage measurement \& calculation & & & & \\
+         \thechptno.2 Battery power for environmental instruments & & & & & \\
+         \thechptno.3 Low-cost solar power systems & & & & & \\
+      \stepcounter{chptno}\thechptno.  \textbf{Water- \& weather-proofing environmental sensing instruments} & & Build a generic waterproof enclosure from clear PVC; consider a system that uses either 2" PVC unions glued to clear plastic for enclosure and to each individual sensor package on the other (expensive because a separate union is required for each experiment). An alternative is to use 1.5" to 2" Fernco coupings that allow connections to the outside of PVC. This allows sensors be potted in 1.5" PVC and swapped out at will, so is much less expensive.  The build could be based on a laser-cut or 3d printed holder that the microcontroller, batteries, and DS3231 could be screwed to. This slides into the 1.5" PVC so ensures the data logging setup is secure even when the clear plastic cap is not mounted.  We should test this. & & & \\
+      \stepcounter{chptno}\thechptno. \textbf{Best practices for data management \& dissemination}   & \thechptno.1 Deployment metadata  &    & &        &      \\
+          \thechptno.1 Deployment metadata  &    & &        &      \\
+          \thechptno.2 Data archiving \& database management & & & & & \\
       \stepcounter{chptno}\thechptno. \textbf{Data telemetry and protocols for sensor communications}   &  &    & &        &      \\
           \thechptno.1 Message Queuing Telemetry Transport (MQTT)    & \thechptno.1.1 Publishing \& subscribing to MQTT messages &    & &        &      \\
              & \thechptno.1.2 Telemetry of sampling requests \& data &  Internet communications   &  &  Data encoding      &   Data handling, security \& accessibility   \\
              & \thechptno.1.3 Logging, archiving \& disseminating MQTT data  & File I/O, data logging    & &        &  Data visualization    \\
-          \thechptno.2 Microcontroller-based web servers   & \thechptno.2.1 Web server setup \& testing &    & &        &      \\
+           \thechptno.2 Representational State Transfer (REST) & \thechptno.2.1 HTTP Get and Put & Post Data to Web Service & Internet communications & Data encoding & Data handling, security, archives    \\
+          \thechptno.3 Microcontroller-based web servers   & \thechptno.2.1 Web server setup \& testing &    & &        &      \\
              & \thechptno.2.2 Data acquisition & dissemination via a web server &  Internet communications   & Data encoding &   Data handling, security \& accessibility   \\
-%
-%
-       |[part]| \textbf{PART III: WORKING WITH ENVIRONMENTAL SENSORS}   & &      & &        &      \\
-
+      \stepcounter{chptno}\thechptno.  \textbf{Computer Aided Design (CAD) \& fabrication} & & & & & \\
+      \stepcounter{chptno}\thechptno.  \textbf{Design of Printed Circuit Boards (PCBs)} & & & & & \\
+       |[part]| \textbf{PART IV: EXPERIMENTS WITH ENVIRONMENTAL SENSORS}   & &      & &        &      \\
+      %
       \stepcounter{chptno}\thechptno. \textbf{Measuring heat and energy flow}   & \thechptno.1 Background: Conservation \& diffusion (conduction) of heat  &    & &        &      \\
           \thechptno.2 Evaporative cooling & \thechptno.2.1 Inferring atmospheric conditions using temperature & Calculate humidity from wet- and dry-bulb temperatures   &  &        &    \\
           \thechptno.3 Heat transfer by conduction & \thechptno.3.1 Measuring heat transfer by conduction   &  Temperature transients \& heat flow in a metal bar &        &    \\
@@ -162,18 +186,23 @@
                  & & \thechptno.4.2 Heat transport in salinity-stratified water columns   &  &        &    \\
                  & & \thechptno.4.3 Heat transport by turbuent mixing   &  &        &    \\
           \thechptno.5 Thermoelectric (Peltier) heating \& cooliing & \thechptno.5.1 Temperature control using a Peltier device & Assemble and code a digital thermostat  & Power modulation \& control & & Feedback \& control   \\
-
+      %
       \stepcounter{chptno}\thechptno.  \textbf{Quantifying light \& color}   &  &    & &        &      \\
           \thechptno.1 Dispersion of collimated \& diffuse light beams  & \thechptno.1.1 Energy conservation \& the $r^2$ law &    &    &    \\
           \thechptno.2 Light attentuation through the water column & \thechptno.2.1 Color-dependence of light absorption  & Digital devices (I2C) &        &    \\
                  &  \thechptno.2.2  Light scattering by suspended particles & Construct a turbidity sensor   &  &        &    \\
                 % &  \thechptno.2.3 Light scattering by atmospheric pollution particles & Use scattering to measure Air Quality Index   &  &        &    \\
           \thechptno.3 Construction, calibration and use of a colorimetric pH sensor   &       \\
-
+      %
+      \stepcounter{chptno}\thechptno.  \textbf{Measuring Sound \& Vibration}   &  &    & &        &      \\
+            \thechptno.1  Sound \& Vibration &\thechptno.1.1 Sound Levels/Amplitude & Record sound levels (Easiest to use RP2040 Connect) &  & Log Scales & Hypothesis: Inverse Distance Squared Relationships \\
+            &\thechptno.16.2 Frequency & Analyze Frequency (Easiest to use RP2040 Connect)  &  & Frequency Domain & Hypothesis: ??? \\
       \stepcounter{chptno}\thechptno.  \textbf{Environmental effects on electrical characteristics}   &  &    & &        &      \\
           \thechptno.1 Capacitance  & \thechptno.1.1  Make a proximity/touch sensor &    &    &    \\
                  & \thechptno.1.2  Use a capacitance touchpad as a Human Interface Devices  &    &    &    \\
                  & \thechptno.1.3  Measuring water levels with capacitance  &    &    &    \\
+                 & \thechptno.1.4 Capacitative Soil Moisture & Record soil moisture before/after lawn irrigation &  & Groundwater & Hypothesis: Mass Conservation \\
+
           \thechptno.2 Conductivity as an indicator of salinity  & \thechptno.2.1  Measuring conductivity & Make a conductivity sensor     &    &    \\
           \thechptno.3 Photoresistors \& photodiodes  & \thechptno.3.1  & & & & \\
           \thechptno.4 Pyroelectric motion detectors  & &    &    &    \\
@@ -182,26 +211,10 @@
                  & \thechptno.5.3 Strain gauges & Measure strain with a Wheatstone bridge & & & \\
 %
 %
-       |[part]| \textbf{PART IV: PRACTICAL SKILLS IN ENVIRONMENTAL SENSING}   & &      & &        &      \\
-
-      \stepcounter{chptno}\thechptno.  \textbf{Computer Aided Design (CAD) \& fabrication} & & & & & \\
-
-      \stepcounter{chptno}\thechptno.  \textbf{Design of Printed Circuit Boards (PCBs)} & & & & & \\
-
-      \stepcounter{chptno}\thechptno.  \textbf{Power supply \& regulation for environmental instruments} & \thechptno.1 Power usage measurement \& calculation & & & & \\
-          \thechptno.2 Battery power for environmental instruments & & & & & \\
-          \thechptno.3 Low-cost solar power systems & & & & & \\
-
-      \stepcounter{chptno}\thechptno.  \textbf{Water- \& weather-proofing environmental sensing instruments} & & & & & \\
 %
 %
        |[part]| \textbf{PART V: QUANTIFYING ENVIRONMENTAL PROCESSES}   & &      & &        &      \\
-
-      \stepcounter{chptno}\thechptno. \textbf{Best practices for data management \& dissemination}   & \thechptno.1 Deployment metadata  &    & &        &      \\
-          \thechptno.1 Deployment metadata  &    & &        &      \\
-          \thechptno.2 Data archiving \& database management & & & & & \\
-
-      \stepcounter{chptno}\thechptno. Monitoring meteorologial conditions \& air chemistry & & & & & \\
+      \stepcounter{chptno}\thechptno. \textbf{Monitoring meteorologial conditions \& air chemistry} & & & & & \\
           \thechptno.1 Monitoring air flow & \thechptno.1.1 Measuring wind speed   & Build and calibrate an anemometer &      \\
                  & \thechptno.1.2 Measuring wind direction   & Build and calibrate a wind vane &      \\
           \thechptno.2 Air chemistry measurements & \thechptno.2.1 Measuring $CO_2$ concentration   & Build and calibrate a $CO_2$ monitor &      \\
@@ -221,10 +234,18 @@
           \thechptno.4 Monitoring waves \& tides   & \thechptno.4.1 Characteristics of water waves & Measure wave amplitude \& frequency with an acoustic distance sensor  & &        &      \\
                  & \thechptno.4.2 Resolving fluctuating signals: Aliasing, Nyquist frequencies \& noise reduction & Assess sampling requirements for resolving water waves & & & \\
                  & \thechptno.4.3 Measurement \& prediction of tides & Analyze a water height time series to predict tides & & & \\
-
-
-
-      \stepcounter{chptno}\thechptno.  \textbf{Tracking position, displacement, velocity \& orientation} & & & & & \\
+      \stepcounter{chptno}\thechptno.  \textbf{Tracking position, displacement, velocity and orientation} & & & & & \\
+      %
+      |[part]| \textbf{APPENDIX: SENSOR ASSEMBLIES/BUILD INSTRUCTIONS. This section provides guidance on sensor/microcontroller configuration, 3-D printed/lasercut mounts, waterproofing/power recommendatins, and build instructions.}   & &      & &        &      \\
+     \stepcounter{deviceno} DEVICE \thedeviceno. Array of DS18B20 (for use on conduction experiment) & & & & \\
+     \stepcounter{deviceno} DEVICE \thedeviceno. MS5803 (for use on depth temperature profiling, water level logging, rainfall measurement, sap measurement) \\
+     \stepcounter{deviceno} DEVICE \thedeviceno. CDT Sensor (for use on profiling, water temprature, water quality) \\
+     \stepcounter{deviceno} DEVICE \thedeviceno. Air Quality Station (for use on CO2, Particulates) \\
+     \stepcounter{deviceno} DEVICE \thedeviceno. Light Sensor \\
+     \stepcounter{deviceno} DEVICE \thedeviceno. pH Sensor \\
+     \stepcounter{deviceno} DEVICE \thedeviceno. Ultrasonic water level sensor \\
+     \stepcounter{deviceno} DEVICE \thedeviceno. Soil moisture sensor \\
+     \stepcounter{deviceno} DEVICE \thedeviceno. Tipping bucket rain gage \\
 };
 % % Simple brace
 % \draw [-,decorate,

--- a/ConceptMap.tex
+++ b/ConceptMap.tex
@@ -103,22 +103,25 @@
           & 3.3.4 Environmental effects on RTC accuracy \& precision \& precision  & Quantifying temperature effects on time-keeping errors   & & Temperature effects on sensors  &      \\
 
       4. Environmental sensing w/ voltage, current and resistance   &  &    & &        &      \\
-      4.1 Measuring voltage    & 4.1.1 Voltage of an 18650 battery &    & &        &      \\
+      4.1 Measuring voltage    & 4.1.1 Voltage of an 18650 battery &    & Using a Multimeter &        &      \\
       & Ohm's Law for voltage, current and resistance &    & & Voltage, current \& resistance/ Ohm's Law   &   Sensor range, resolution \& saturation (ADC voltage limits \& resolution)   \\
       & Designing a voltage divider using Ohm's Law & Design a voltage divider circuit   & Ohm's Law calculations  &        & Circuit design, analysis \& testing     \\
       &  & Assemble/test a voltage divider circuit   & Breadboard circuit layout \& debugging &        &   \\
-      4.2 Environmental sensing w/ voltage: measure voltage w/ a thermistor    & 4.2.1 Thermistor temperature resistance curves & Calibrate a thermistor   & &   Temperature effects on sensors     &      \\
+      4.2 Environmental sensing w/ voltage \& current: temperature and conductivity with thermistor/EC electrodes    & 4.2.1 Thermistor temperature resistance curves & Calibrate a thermistor   & &   Temperature effects on sensors     &      \\
            & 4.2.2 Thermistor circuit design & Design a voltage divider for a thermistor   & GPIO interfaces (ADC) &  Data encoding  &  Calibration \& ground truthing    \\
            & 4.2.3 Thermistor circuit assembly \& programming & Build \& test a thermistor circuit   & &        &      \\
+          & 4.2.4 Electrical Conductivity Measurement & Assemble \& calibrate EC electrodes in parallel with thermistor & GPIO interfaces (Digital output, current limits), Classes in Python & Parallel circuits (thermistor and EC in parallel), AC vs. DC & Temperature dependence, sensitivity across range of ADC, calibration     \\
       4.3 Environmental sensing w/ time: measuring light intensity with frequency    & 4.3.1 Measuring light with frequency & Assemble \& test a frequency-based light sensor circuit   & Breadboard circuit layout \& debugging &        &      \\
            & 4.3.2 Dividing frequency to increase sensor range & Measure divided frequency from a light sensor   & GPIO interfaces & Microcontroller responses to environmental signals       &      Sensor range, resolution \& saturation ($\mu s$ measurement limits)\\
            & 4.3.3 Optimizing a light sensor driver & Optimize a light sensor driver   & Python coding (drivers) &        &      \\
       4.4 ****Environmental sensing with time: Calibrate an acoustic distance sensor   &  &      \\
       4.5 ****Environmental sensing with magnetism: measuring current and wind velocity   &  &      \\
+      4.6 ****Environmental sensing with acceleration and vibration:  measuring wave period amplitude with accelerometer &&&& Sampling Frequency \\
 
       5. Digital interfaces for environmental sensors   & 5.0.1 Communicating with digital sensors &    & &        &      \\
       5.1 ****I2C sensors   & 5.1.1 Background &      \\
              & 5.1.2 Measuring temperature with a high-resolution sensor   &  &        &    \\
+             & 5.1.3 Multiple Sensors on a Device: Temperature and Pressure on MS5803  &   Water depth/temperature profiles &    Printed Circuit Boards/SMT Assembly   & Hydrostatics, temperature stratification & Sensor Range and Error Propagation  \\
              & 5.1.3 Dispersion of collimated \& diffuse light beams  & Digital devices (I2C) &        &    \\
              & 5.1.4 Construction, calibration and use of a colorimetric pH sensor   &       \\
              & 5.1.5 Using I2C over long cables with differential extenders   &  &        &    \\
@@ -150,6 +153,16 @@
                  & 6.1.3 Logging, archiving \& disseminating MQTT data  & File I/O, data logging    & &        &  Data visualization    \\
       6.2 Microcontroller-based web servers   & 6.2.1 Web server setup \& testing &    & &        &      \\
                  & 6.2.2 Data acquisition & dissemination via a web server &  Internet communications   & Data encoding &   Data handling, security \& accessibility   \\
+      7. Use of sensors in the field  &  &    & Deployment, battery life, data storage needs &   & Documentation, Data management and archiving    \\
+      8. Potential Sensing Projects--Scientific Hypotheses  & & & Water Proofing, Battery Life & Data Encoding   &  Field Protocol      \\
+                & 8.1 Log Depth by differencing MS5803 from BMP280 & Measure rainfall, evaporation, and/or sap accumulation in bucket &  & Precipitation Processes, snow vs. rain, weather and climate, plant physiology, atmospheric pressure & Hypothesis: Biological Sensitivity to Temperature\\
+                & 8.2 Depth Profiling w/ EC/ MS5803 pressure device  & Create CDT profiles in lake/pond/estuary &  & Water Quality& Hypothesis: Stratification \\
+                & 8.3 Wave period/amplitude w/ Accoustic/pressure/acceleration devices & Record wave statistics on nearby body of water &  & Energy and Frequency, Sampling Frequency & Hypothesis: Dependence on Fetch\\
+                & 8.4 Capacitative Soil Moisture & Record soil moisture before/after lawn irrigation & & Groundwater & Hypothesis: Mass Conservation \\
+                & 8.5 Logging Direction or position w/ accelerometer or magnetometer or GPS & Record direction of flow in tidal body of water &  & Tides & Hypothesis: Tidal Exchange \\
+                & 8.6 Air Quality Monitor & Record CO2 and Particulate matter decay in Classroom, kitchen, etc. after seeding & & Mixing & Hypothesis: Exponential Decay\\
+                & 8.7 Record sound levels (Easiest to use RP2040 Connect) & Look for Inverse Distance Squared decrease in sound energy &  & Log Scales & Hypothesis: Inverse Distance Relationships ??? \\
+                & 8.8 Use TSL23X to record light & Record PAR ??? (Need filter) &  & Spectra, Log Scales & Hypothesis: Dependence on Solar Angle and/or correlation with temperature ??? \\
 %
       %
       %1.1 Estab. Comms    &  &    & &        &      \\

--- a/ConceptMap.tex
+++ b/ConceptMap.tex
@@ -64,18 +64,23 @@
     {
       %& &  |[root]| Prosection               \\
       |[blank]|Section     & |[blank]|Background  & |[blank]|Activity/HOW-TO/ Milestone  & |[blank]|Skill &  |[blank]|Science/Engineering topic & |[blank]|Core concept  \\
+      0. Introduction   & 0.1 Technological change, Microcontrollers & Assemble materials & & Differences between microcontroller types & Distinction between microcontroller, single-board computer, computer, and commercial sensors  \\
+      & 0.2 Required Software, Development Tools & Acquire/Install Required Software, Flash Micropython & Software Installation, Operating Systems  & Language Versioning      \\
       1. Communicating w/ your microcontroller   & & Meet your microcontroller     & &        &      \\
       1.1 Establishing communications    &  &    & &        &      \\
       1.2 Connecting via USB    & 1.2.1 Installing drivers for USB &    & &        &      \\
-          & 1.2.2 USB connections via Chrome & Connect via BeagleTerm & Wired communication with microcontrollers &        &      \\
-          & 1.2.3 USB connections via mpfshell &   Install mpfshell & &        &      \\
+          & 1.2.2 USB REPL connections via Chrome & Connect via BeagleTerm & Wired communication with microcontrollers &        &      \\
+          & 1.2.3 USB REPL connections via mpfshell &   Install mpfshell & &        &      \\
           &  &   Connect via mpfshell & &        &      \\
+          &  &   Connect to REPL via Thonny & &        &      \\
+          & File Management in Micropython &   File transfer via Thonny & Main loops in a program, Running at boot (boot.py, main.py) &        &      \\
       1.3 Connecting via WiFi     & 1.3.1 WiFi access points \& stations &  Configure/connect to AP  &  &        &      \\
                                  &   &  Configure/connect in station mode  & &        &      \\
            & 1.3.2 WiFi connections via WebREPL &  Launch WebREPL  & Wireless communications with microcontrollers &        & Fundamentals of microcontroller function     \\
                                  &   &  Upload a file  & &        &      \\
                                  &   &  Download a file  & &        &      \\
            & 1.3.3 WiFi connections via mpfshell & Connect over WiFi w/ mpfshell  & &        &      \\
+           & 1.3.4 WiFi connections via Thonny (if possible) & Connect over WiFi with Thonny  & &        &      \\
       1.4 Computing on your microcontroller    &  1.4.1 Generating random numbers and strings &  Generate random numbers and strings  & & Pseudo-random number generation         &      \\
           & 1.4.2 Encryption of character strings &  Encrypt/decrypt messages  & Python coding &        &  \\
           & 1.4.3 Encrypted authentication of data messages &  Verify a data message  & &  Data encoding (Hexadecimal system, refer to UART section?)    &  Data handling, security \& accessibility    \\


### PR DESCRIPTION
In this model for the concept map, the course is organized mostly around sensor communication protocols, as before, but there is a new section at the end that focuses on application.  

The big changes are 

1. Linking electrical conductivity measurements into the voltage measurement section (a natural fit, because it requires a thermistor anyway and requires a current estimate, which is also ADC-based),  
2. Adding a section for the MS5803 sensor under I2C, also a natural fit because it introduces the concept more than one built in I2C sensor on the bus, and
3. Covering the scientific hypothesis section by adding a laundry-list of potential projects in a new chapter 7. 

A difference between the projects in the laundry list and projects in the other chapters is that the laundry-list projects should provide practical pointers for making a deployable sensor.  This is not the pedagogical purpose of the projects in the other chapters.  The big difference is that most (or really all) projects in chapter 8 should be plug-and-play and sufficiently secure for a field deployment that addresses the scientific hypotheses motivating each chapter.  Based on my experience, they should avoid the use of breadboards at all costs.  Most of these projects would be built by directly wiring the sensor to the microcontroller using DuPont connectors and/or by direct soldered connections.  